### PR TITLE
[RHOAIENG-99] Change metrics service pod target to 8080 (#187)

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -16,6 +16,6 @@ spec:
     - name: https
       port: 8443
       protocol: TCP
-      targetPort: https
+      targetPort: 8080
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
Change operator's metric service target port to `8080`. 