### PR TITLE
disable renovate for konflux updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,7 +45,7 @@
           "^quay.io/konflux-ci/tekton-catalog/"
         ],
         "matchUpdateTypes": ["digest"],
-        "enabled": true,
+        "enabled": false,
         "groupName": "Konflux references",
         "branchPrefix": "konflux/references/",
         "group": {


### PR DESCRIPTION
due to issue with task-coverity-availability-check-oci-ta image