### PR TITLE
add condition to send-slack-notification

### DIFF
--- a/.tekton/ta-lmes-driver-v2-19-push.yaml
+++ b/.tekton/ta-lmes-driver-v2-19-push.yaml
@@ -71,6 +71,10 @@ spec:
         operator: in
         values:
         - "Failed"  
+      - input: $(tasks.prefetch-dependencies.status)
+        operator: notin
+        values:
+        - "None"  
     params:
     - description: Source Repository URL
       name: git-url


### PR DESCRIPTION
This is to fix an issue specific to components that are both on internal and external konflux. On repo updates, a pipeline meant for external will briefly run on internal but get quickly terminated. We send our slack message on any failures, so we end up getting a notification.
