### PR TITLE
fix(RHOAIENG-23562): Update OAuth proxy image in params.env

### DIFF
--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,6 +1,6 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
-oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
+oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695
 kServeServerless=enabled
 lmes-driver-image=quay.io/modh/ta-lmes-driver@sha256:6827744f7a12959a4742c855c5c7907312068a16d438f8bde7430e3cf048d552
 lmes-pod-image=quay.io/modh/ta-lmes-job@sha256:5da34c209547d12964fc3f19f2670169a1363a43cf91e1ef022c26a7bbd17081


### PR DESCRIPTION
Bring https://github.com/trustyai-explainability/trustyai-service-operator/pull/447 to the `rhoai-2.20` branch.