### PR TITLE
fix(RHOAIENG-25052): Update OAuth proxy image in RHOAI overlay

### DIFF
--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,6 +1,6 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
-oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
+oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695
 kServeServerless=enabled
 lmes-driver-image=quay.io/modh/ta-lmes-driver@sha256:52d9b04cd1ad315f68cb530d0c3e5a904e0752e141fc667ae127b5f8cbc77932
 lmes-pod-image=quay.io/modh/ta-lmes-job@sha256:4e5a917b973b049c9504ed5302f91130258c2ee99a23d5ad23b7f59504404eac


### PR DESCRIPTION
Cherry pick of https://github.com/red-hat-data-services/trustyai-service-operator/commit/4e925ac419766ba2ea45df30bca228e43eda7c85.

Refer to [RHOAIENG-25052](https://issues.redhat.com/browse/RHOAIENG-25052)