### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-trustyai-service-operator-v2-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -40,7 +40,8 @@ USER 65532:65532
 ENTRYPOINT ["/manager"]
 
 LABEL com.redhat.component="odh-trustyai-service-operator-container" \
-      name="managed-open-data-hub/odh-trustyai-service-operator-rhel8" \
+      name="rhoai/odh-trustyai-service-operator-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="The TrustyAI Operator manages TrustyAI deployments within a k8s cluster" \
       summary="odh-trustyai-service-operator" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
