### PR TITLE
chore(operator): update TrustyAI operator downstream to gotoolset 1.25

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -2,7 +2,7 @@
 ARG SOURCE_CODE=.
 
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23@sha256:381fb72f087a07432520fa93364f66b5981557f1dd708f3c4692d6d0a76299b3 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.konflux.driver
+++ b/Dockerfile.konflux.driver
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999 AS builder
 
 WORKDIR /go/src/github.com/trustyai-explainability/trustyai-service-operator
 # Copy the Go Modules manifests


### PR DESCRIPTION
  The current gotoolset version is outdated. Updating to 1.25 will:
  * Pick up the latest Go security fixes
  * Align with the latest supported Go toolchain for RHEL 9
  * Ensure compatibility with upstream Go module requirements

`Dockerfile` and `Dockerfile.driver` will be updated upstream.

Refer to [RHOAIENG-60339](https://redhat.atlassian.net/browse/RHOAIENG-60339)