### PR TITLE
fix(evalhub): port PR #738 ConfigMap namespace lookup to rhoai-3.4

### DIFF
--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -394,7 +394,7 @@ func TestBuildServiceSpec(t *testing.T) {
 	})
 }
 
-func TestGetEvalHubImage(t *testing.T) {
+func TestGetImageFromConfigMap(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 
@@ -422,12 +422,12 @@ func TestGetEvalHubImage(t *testing.T) {
 			Namespace: testNamespace,
 		}
 
-		image, err := reconciler.getEvalHubImage(ctx)
+		image, err := reconciler.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
 		require.NoError(t, err)
 		assert.Equal(t, "quay.io/test/eval-hub:custom", image)
 	})
 
-	t.Run("should return fallback image when configmap not found", func(t *testing.T) {
+	t.Run("returns error when configmap not found", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			Build()
@@ -437,34 +437,19 @@ func TestGetEvalHubImage(t *testing.T) {
 			Namespace: testNamespace,
 		}
 
-		image, err := reconciler.getEvalHubImage(ctx)
-		require.Error(t, err)                       // Error is expected when configmap not found
-		assert.Equal(t, defaultEvalHubImage, image) // But fallback image is returned
+		_, err := reconciler.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
 	})
 
-	t.Run("should use default namespace when namespace not set", func(t *testing.T) {
-		configMap := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
-				Namespace: "trustyai-service-operator-system",
-			},
-			Data: map[string]string{
-				configMapEvalHubImageKey: "quay.io/test/eval-hub:default-ns",
-			},
-		}
-
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(configMap).
-			Build()
-
+	t.Run("returns error when reconciler namespace is empty", func(t *testing.T) {
 		reconciler := &EvalHubReconciler{
-			Client:    fakeClient,
-			Namespace: "", // Empty namespace should use default
+			Client:    fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Namespace: "",
 		}
 
-		image, err := reconciler.getEvalHubImage(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, "quay.io/test/eval-hub:default-ns", image)
+		_, err := reconciler.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "operator namespace not set")
 	})
 }

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	evalhubv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1alpha1"
-	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -68,7 +67,7 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 	}
 
 	// Get image from ConfigMap with fallback
-	evalHubImage, err := r.getEvalHubImage(ctx)
+	evalHubImage, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Error getting EvalHub image from ConfigMap. Using the default image value of "+defaultEvalHubImage)
 		evalHubImage = defaultEvalHubImage
@@ -345,18 +344,6 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			},
 		},
 	}, nil
-}
-
-// getEvalHubImage retrieves the EvalHub image from ConfigMap with fallback to default
-func (r *EvalHubReconciler) getEvalHubImage(ctx context.Context) (string, error) {
-	// Get the namespace where the operator is deployed (where the ConfigMap should be)
-	namespace := r.Namespace
-	if namespace == "" {
-		// Fallback to default namespace if not set
-		namespace = "trustyai-service-operator-system"
-	}
-
-	return utils.GetImageFromConfigMapWithFallback(ctx, r.Client, configMapEvalHubImageKey, configMapName, namespace, defaultEvalHubImage)
 }
 
 // mergeEnvVars merges default environment variables with CR-specified ones,

--- a/controllers/evalhub/suite_test.go
+++ b/controllers/evalhub/suite_test.go
@@ -187,7 +187,7 @@ func setupReconciler(namespace string) (*EvalHubReconciler, context.Context) {
 		EventRecorder: eventRecorder,
 	}
 
-	// Create the operator image ConfigMap so getEvalHubImage succeeds.
+	// Create the operator image ConfigMap so getImageFromConfigMap succeeds.
 	operatorCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName,


### PR DESCRIPTION
This is a port of https://github.com/trustyai-explainability/trustyai-service-operator/pull/738 from upstream.

Replace getEvalHubImage (hardcoded trustyai-service-operator-system fallback) with getImageFromConfigMap so EvalHub deployment image lookup uses the operator's configured namespace only.

Fixes RHOAIENG-63756