### PR TITLE
feat(images): add RELATED_IMAGE_* env var support for operand image resolution (#766)

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -93,3 +93,38 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.lmes-pod-image
+  - name: lmes-driver-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.lmes-driver-image
+  - name: guardrails-orchestrator-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.guardrails-orchestrator-image
+  - name: guardrails-built-in-detector-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.guardrails-built-in-detector-image
+  - name: guardrails-sidecar-gateway-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.guardrails-sidecar-gateway-image
+  - name: nemo-guardrails-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.nemo-guardrails-image

--- a/config/base/params.yaml
+++ b/config/base/params.yaml
@@ -2,5 +2,7 @@
 varReference:
   - kind: Deployment
     path: spec/template/spec/containers[]/image
+  - kind: Deployment
+    path: spec/template/spec/containers[]/env[]/value
   - kind: ConfigMap
     path: data

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,26 @@ spec:
           env:
             - name: GOMEMLIMIT
               value: "630MiB"
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
+              value: $(trustyaiServiceImage)
+            - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
+              value: $(evalHubImage)
+            - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+              value: $(kube-rbac-proxy)
+            - name: RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
+              value: $(lmes-pod-image)
+            - name: RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
+              value: $(lmes-driver-image)
+            - name: RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE
+              value: $(guardrails-orchestrator-image)
+            - name: RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE
+              value: $(guardrails-built-in-detector-image)
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE
+              value: $(guardrails-sidecar-gateway-image)
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
+              value: $(garak-provider-image)
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE
+              value: $(nemo-guardrails-image)
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -216,7 +216,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 
 		_, err := r.buildDeploymentSpec(ctx, evalHub, nil, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
+		Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
 	})
 
 	It("adds provider volume and mount when providerCMNames is non-nil", func() {

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,9 +148,9 @@ func (r *EvalHubReconciler) reconcileConfigMap(ctx context.Context, instance *ev
 
 // generateConfigData generates the configuration data for the ConfigMap
 func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *evalhubv1.EvalHub) (map[string]string, error) {
-	evalHubImage, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, r.effectiveOperatorConfigMapName(), r.Namespace, defaultEvalHubImage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get EvalHub image: %w", err)
+		return nil, fmt.Errorf("resolving EvalHub image: %w", err)
 	}
 
 	config := EvalHubConfig{

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -66,16 +67,15 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 		"component": "api",
 	}
 
-	// Get image from ConfigMap with fallback
-	evalHubImage, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+	// Get image using the centralized resolver (env var → configmap → fallback)
+	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, r.effectiveOperatorConfigMapName(), r.Namespace, defaultEvalHubImage)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Error getting EvalHub image from ConfigMap. Using the default image value of "+defaultEvalHubImage)
-		evalHubImage = defaultEvalHubImage
+		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving EvalHub image: %w", err)
 	}
 
-	kubeRBACProxyImage, err := r.getImageFromConfigMap(ctx, configMapKubeRBACProxyImageKey)
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, r.effectiveOperatorConfigMapName(), r.Namespace, "")
 	if err != nil {
-		return appsv1.DeploymentSpec{}, fmt.Errorf("getting kube-rbac-proxy image: %w", err)
+		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving kube-rbac-proxy image: %w", err)
 	}
 
 	settings := mergeEvalHubDeploymentOperatorSettings(ctx, r.readOperatorConfigMapData(ctx))

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -319,7 +319,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 			err = reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
+			Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
 		})
 
 		It("should configure rolling update strategy", func() {
@@ -696,6 +696,6 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 		}
 		err := r.reconcileDeployment(ctx, fh, nil, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
+		Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
 	})
 })

--- a/controllers/evalhub/mcp_deployment.go
+++ b/controllers/evalhub/mcp_deployment.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,16 +82,15 @@ func (r *EvalHubReconciler) buildMCPDeploymentSpec(ctx context.Context, instance
 	image := mcpSpec.Image
 	if image == "" {
 		var err error
-		image, err = r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+		image, err = images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, r.effectiveOperatorConfigMapName(), r.Namespace, defaultEvalHubImage)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "Error getting EvalHub image for MCP from ConfigMap, using default "+defaultEvalHubImage)
-			image = defaultEvalHubImage
+			return appsv1.DeploymentSpec{}, fmt.Errorf("resolving EvalHub image for MCP: %w", err)
 		}
 	}
 
-	kubeRBACProxyImage, err := r.getImageFromConfigMap(ctx, configMapKubeRBACProxyImageKey)
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, r.effectiveOperatorConfigMapName(), r.Namespace, "")
 	if err != nil {
-		return appsv1.DeploymentSpec{}, fmt.Errorf("getting kube-rbac-proxy image for MCP: %w", err)
+		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving kube-rbac-proxy image for MCP: %w", err)
 	}
 
 	settings := mergeEvalHubDeploymentOperatorSettings(ctx, r.readOperatorConfigMapData(ctx))

--- a/controllers/gorch/auth.go
+++ b/controllers/gorch/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	gorchv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/gorch/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/gorch/templates"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -12,12 +13,12 @@ import (
 
 // configureKubeRBACProxy creates the kube-rbac-proxy config structs to be used in the deployment template
 func (r *GuardrailsOrchestratorReconciler) configureKubeRBACProxy(ctx context.Context, orchestrator *gorchv1alpha1.GuardrailsOrchestrator, deploymentConfig *DeploymentConfig) error {
-	kubeRBACProxyImage, err := utils.GetImageFromConfigMap(ctx, r.Client, kubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
+	kubeRBACProxyImage, err := images.GetImageFromConfigMap(ctx, r.Client, kubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
 	if kubeRBACProxyImage == "" || err != nil {
-		log.FromContext(ctx).Error(err, "Error getting Kube-RBAC-Proxy image from ConfigMap.")
+		log.FromContext(ctx).Error(err, "Error resolving Kube-RBAC-Proxy image from env var or ConfigMap.")
 		return err
 	}
-	log.FromContext(ctx).Info("Using kube-rbac-proxy image " + kubeRBACProxyImage + " " + "from configmap " + r.Namespace + ":" + constants.ConfigMap)
+	log.FromContext(ctx).Info("Using kube-rbac-proxy image " + kubeRBACProxyImage)
 
 	deploymentConfig.OrchestratorKubeRBACProxy = &utils.KubeRBACProxyConfig{
 		Suffix:             "orchestrator",

--- a/controllers/gorch/deployment.go
+++ b/controllers/gorch/deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	gorchv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/gorch/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/gorch/templates"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,32 +34,33 @@ type DeploymentConfig struct {
 func (r *GuardrailsOrchestratorReconciler) createDeployment(ctx context.Context, orchestrator *gorchv1alpha1.GuardrailsOrchestrator) (*appsv1.Deployment, error) {
 	var containerImages ContainerImages
 
-	orchestratorImage, err := utils.GetImageFromConfigMap(ctx, r.Client, orchestratorImageKey, constants.ConfigMap, r.Namespace)
+	orchestratorImage, err := images.GetImageFromConfigMap(ctx, r.Client, orchestratorImageKey, constants.ConfigMap, r.Namespace)
 	if orchestratorImage == "" || err != nil {
-		log.FromContext(ctx).Error(err, "Error getting container image from ConfigMap.")
+		log.FromContext(ctx).Error(err, "Error resolving orchestrator image from env var or ConfigMap.")
 		return nil, err
 	}
 	containerImages.OrchestratorImage = orchestratorImage
-	log.FromContext(ctx).Info("using OrchestratorImage " + orchestratorImage + " " + "from config map " + r.Namespace + ":" + constants.ConfigMap)
+	log.FromContext(ctx).Info("using OrchestratorImage " + orchestratorImage)
 
 	// Check if the regex detectors are enabled
 	if orchestrator.Spec.EnableBuiltInDetectors {
-		detectorImage, err := utils.GetImageFromConfigMap(ctx, r.Client, detectorImageKey, constants.ConfigMap, r.Namespace)
+		detectorImage, err := images.GetImageFromConfigMap(ctx, r.Client, detectorImageKey, constants.ConfigMap, r.Namespace)
 		if detectorImage == "" || err != nil {
-			log.FromContext(ctx).Error(err, "Error getting detectors image from ConfigMap.")
+			log.FromContext(ctx).Error(err, "Error resolving detector image from env var or ConfigMap.")
 			return nil, err
 		}
-		log.FromContext(ctx).Info("Using detector image " + detectorImage + " " + "from configmap " + r.Namespace + ":" + constants.ConfigMap)
+		log.FromContext(ctx).Info("Using detector image " + detectorImage)
 		containerImages.DetectorImage = detectorImage
 	}
 
 	// Check if the guardrails sidecar gateway is enabled
 	if orchestrator.Spec.EnableGuardrailsGateway {
-		guardrailsGatewayImage, err := utils.GetImageFromConfigMap(ctx, r.Client, gatewayImageKey, constants.ConfigMap, r.Namespace)
+		guardrailsGatewayImage, err := images.GetImageFromConfigMap(ctx, r.Client, gatewayImageKey, constants.ConfigMap, r.Namespace)
 		if guardrailsGatewayImage == "" || err != nil {
-			log.FromContext(ctx).Error(err, "Error getting guardrails sidecar gateway image from ConfigMap.")
+			log.FromContext(ctx).Error(err, "Error resolving guardrails sidecar gateway image from env var or ConfigMap.")
+			return nil, err
 		}
-		log.FromContext(ctx).Info("Using sidecar gateway image " + guardrailsGatewayImage + " " + "from configmap " + r.Namespace + ":" + constants.ConfigMap)
+		log.FromContext(ctx).Info("Using sidecar gateway image " + guardrailsGatewayImage)
 		containerImages.GuardrailsGatewayImage = guardrailsGatewayImage
 	}
 

--- a/controllers/images/resolver.go
+++ b/controllers/images/resolver.go
@@ -1,0 +1,134 @@
+package images
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Image key constants matching ConfigMap keys
+const (
+	TrustyAIServiceImageKey           = "trustyaiServiceImage"
+	EvalHubImageKey                   = "evalHubImage"
+	KubeRBACProxyKey                  = "kube-rbac-proxy"
+	LMESPodImageKey                   = "lmes-pod-image"
+	LMESDriverImageKey                = "lmes-driver-image"
+	GuardrailsOrchestratorImageKey    = "guardrails-orchestrator-image"
+	GuardrailsBuiltInDetectorImageKey = "guardrails-built-in-detector-image"
+	GuardrailsSidecarGatewayImageKey  = "guardrails-sidecar-gateway-image"
+	GarakProviderImageKey             = "garak-provider-image"
+	NemoGuardrailsImageKey            = "nemo-guardrails-image"
+)
+
+// Environment variable names following RELATED_IMAGE_ODH_* convention
+const (
+	RelatedImageTrustyAIService          = "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE"
+	RelatedImageEvalHub                  = "RELATED_IMAGE_ODH_EVAL_HUB_IMAGE"
+	RelatedImageKubeRBACProxy            = "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE"
+	RelatedImageLMESJob                  = "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE"
+	RelatedImageLMESDriver               = "RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE"
+	RelatedImageGuardrailsOrchestrator   = "RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE"
+	RelatedImageBuiltInDetector          = "RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE"
+	RelatedImageVLLMOrchestratorGateway  = "RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE"
+	RelatedImageGarakLLSProviderDSP      = "RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE"
+	RelatedImageNemoGuardrailsServer     = "RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE"
+)
+
+// imageMapping maps ConfigMap keys to their corresponding RELATED_IMAGE_* environment variable names
+var imageMapping = map[string]string{
+	TrustyAIServiceImageKey:           RelatedImageTrustyAIService,
+	EvalHubImageKey:                   RelatedImageEvalHub,
+	KubeRBACProxyKey:                  RelatedImageKubeRBACProxy,
+	LMESPodImageKey:                   RelatedImageLMESJob,
+	LMESDriverImageKey:                RelatedImageLMESDriver,
+	GuardrailsOrchestratorImageKey:    RelatedImageGuardrailsOrchestrator,
+	GuardrailsBuiltInDetectorImageKey: RelatedImageBuiltInDetector,
+	GuardrailsSidecarGatewayImageKey:  RelatedImageVLLMOrchestratorGateway,
+	GarakProviderImageKey:             RelatedImageGarakLLSProviderDSP,
+	NemoGuardrailsImageKey:            RelatedImageNemoGuardrailsServer,
+}
+
+// GetImageFromConfigMap is the legacy function signature that now uses the unified resolver.
+// Deprecated: Use ResolveImage directly for better clarity.
+func GetImageFromConfigMap(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string) (string, error) {
+	return ResolveImage(ctx, c, configMapKey, configMapName, namespace, "")
+}
+
+// GetImageFromConfigMapWithFallback is the legacy function signature with a default fallback value.
+// Deprecated: Use ResolveImage directly for better clarity.
+func GetImageFromConfigMapWithFallback(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string, fallbackValue string) (string, error) {
+	if namespace == "" {
+		return fallbackValue, nil
+	}
+	image, err := ResolveImage(ctx, c, configMapKey, configMapName, namespace, fallbackValue)
+	if err != nil {
+		return fallbackValue, err
+	}
+	return image, nil
+}
+
+// ResolveImage resolves an operand image URL by checking in this order:
+//  1. RELATED_IMAGE_ODH_* environment variable (if configMapKey is recognized)
+//  2. ConfigMap value at configMapKey
+//  3. fallbackValue (if provided and non-empty)
+//
+// Returns an error if none of the above sources provide a value.
+func ResolveImage(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string, fallbackValue string) (string, error) {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Check if there's a corresponding RELATED_IMAGE_* env var
+	if envVarName, ok := imageMapping[configMapKey]; ok {
+		if envValue := os.Getenv(envVarName); envValue != "" {
+			logger.Info("resolved image", "key", configMapKey, "source", "env", "var", envVarName, "value", envValue)
+			return envValue, nil
+		}
+	}
+
+	// Step 2: Fall back to ConfigMap
+	image, err := getImageFromConfigMapDirect(ctx, c, configMapKey, configMapName, namespace)
+	if err == nil && image != "" {
+		logger.Info("resolved image", "key", configMapKey, "source", "configmap", "name", configMapName, "namespace", namespace, "value", image)
+		return image, nil
+	}
+
+	// Step 3: Use fallback value if provided
+	if fallbackValue != "" {
+		logger.Info("resolved image", "key", configMapKey, "source", "fallback", "value", fallbackValue)
+		return fallbackValue, nil
+	}
+
+	// No value found
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve image for key %s: %w", configMapKey, err)
+	}
+	return "", fmt.Errorf("no image value found for key %s (env var, configmap, or fallback)", configMapKey)
+}
+
+// getImageFromConfigMapDirect is an internal helper that directly reads from ConfigMap without env var check.
+// This is used internally by ResolveImage to avoid circular logic.
+func getImageFromConfigMapDirect(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string) (string, error) {
+	// Inline implementation to avoid circular import with controllers/utils.
+	// TODO: Refactor to shared pkg/configmap package to eliminate duplication.
+	// See https://github.com/trustyai-explainability/trustyai-service-operator/issues/783
+
+	configMap := &corev1.ConfigMap{}
+	err := c.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", fmt.Errorf("configmap %s not found in namespace %s", configMapName, namespace)
+		}
+		return "", fmt.Errorf("error reading configmap %s in namespace %s: %w", configMapName, namespace, err)
+	}
+
+	value, ok := configMap.Data[configMapKey]
+	if !ok {
+		return "", fmt.Errorf("configmap %s in namespace %s does not contain key %s", configMapName, namespace, configMapKey)
+	}
+	return value, nil
+}

--- a/controllers/images/resolver_test.go
+++ b/controllers/images/resolver_test.go
@@ -1,0 +1,233 @@
+package images
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Image Resolver", func() {
+	var cleanupEnvVars = func() {
+		Expect(os.Unsetenv(RelatedImageTrustyAIService)).To(Succeed())
+	}
+
+	AfterEach(func() {
+		cleanupEnvVars()
+	})
+
+	Describe("ResolveImage", func() {
+		Context("when environment variable is set", func() {
+			It("should use the environment variable value over ConfigMap", func() {
+				// Create a fake client with a ConfigMap containing an image
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+				// Set the environment variable
+				Expect(os.Setenv(RelatedImageTrustyAIService, testImageFromEnv)).To(Succeed())
+
+				// Resolve the image
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromEnv))
+			})
+		})
+
+		Context("when environment variable is not set", func() {
+			It("should use ConfigMap value", func() {
+				// Create a fake client with a ConfigMap
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+				// Ensure env var is NOT set
+				cleanupEnvVars()
+
+				// Resolve the image
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromCM))
+			})
+		})
+
+		Context("when environment variable is empty", func() {
+			It("should use ConfigMap value", func() {
+				// Create a fake client with a ConfigMap
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+				// Set env var to empty string
+				Expect(os.Setenv(RelatedImageTrustyAIService, "")).To(Succeed())
+
+				// Resolve the image
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromCM))
+			})
+		})
+
+		Context("when neither env var nor ConfigMap are available", func() {
+			It("should use fallback value", func() {
+				// Create a fake client with NO ConfigMap
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				// Ensure env var is NOT set
+				cleanupEnvVars()
+
+				// Resolve the image with fallback
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
+
+			It("should return error when no fallback is provided", func() {
+				// Create a fake client with NO ConfigMap
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				// Ensure env var is NOT set
+				cleanupEnvVars()
+
+				// Resolve the image without fallback
+				_, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when ConfigMap exists but is missing the key", func() {
+			It("should use fallback value", func() {
+				// Create a ConfigMap without the expected key
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"some-other-key": "some-value",
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+				// Ensure env var is NOT set
+				cleanupEnvVars()
+
+				// Resolve the image with fallback
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
+		})
+	})
+
+	Describe("Image Mappings", func() {
+		It("should have all 10 expected image mappings", func() {
+			expectedMappings := map[string]string{
+				TrustyAIServiceImageKey:           RelatedImageTrustyAIService,
+				EvalHubImageKey:                   RelatedImageEvalHub,
+				KubeRBACProxyKey:                  RelatedImageKubeRBACProxy,
+				LMESPodImageKey:                   RelatedImageLMESJob,
+				LMESDriverImageKey:                RelatedImageLMESDriver,
+				GuardrailsOrchestratorImageKey:    RelatedImageGuardrailsOrchestrator,
+				GuardrailsBuiltInDetectorImageKey: RelatedImageBuiltInDetector,
+				GuardrailsSidecarGatewayImageKey:  RelatedImageVLLMOrchestratorGateway,
+				GarakProviderImageKey:             RelatedImageGarakLLSProviderDSP,
+				NemoGuardrailsImageKey:            RelatedImageNemoGuardrailsServer,
+			}
+
+			Expect(imageMapping).To(HaveLen(len(expectedMappings)))
+
+			for key, expectedEnvVar := range expectedMappings {
+				Expect(imageMapping).To(HaveKeyWithValue(key, expectedEnvVar))
+			}
+		})
+	})
+
+	Describe("Legacy Functions", func() {
+		Describe("GetImageFromConfigMap", func() {
+			It("should maintain backward compatibility", func() {
+				// Create a ConfigMap
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+				// Ensure env var is NOT set
+				cleanupEnvVars()
+
+				// Call the legacy function
+				image, err := GetImageFromConfigMap(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromCM))
+			})
+		})
+
+		Describe("GetImageFromConfigMapWithFallback", func() {
+			It("should use fallback when ConfigMap is missing", func() {
+				// Create a fake client with NO ConfigMap
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				// Ensure env var is NOT set
+				cleanupEnvVars()
+
+				// Call the legacy function with fallback
+				image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
+
+			It("should return fallback immediately when namespace is empty", func() {
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				// When namespace is empty, should return fallback immediately
+				image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, "", testFallback)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
+		})
+	})
+})

--- a/controllers/images/suite_test.go
+++ b/controllers/images/suite_test.go
@@ -1,0 +1,39 @@
+package images
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Test constants
+const (
+	testNamespace    = "test-namespace"
+	testConfigMap    = "test-configmap"
+	testImageFromCM  = "quay.io/trustyai/service:from-configmap"
+	testImageFromEnv = "quay.io/trustyai/service:from-env-var"
+	testFallback     = "quay.io/trustyai/service:fallback"
+)
+
+var (
+	ctx    context.Context
+	scheme *runtime.Scheme
+)
+
+func TestImages(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Images Resolver Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx = context.Background()
+	scheme = runtime.NewScheme()
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+})

--- a/controllers/lmes/config.go
+++ b/controllers/lmes/config.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/dsc"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/lmes/driver"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -116,6 +117,26 @@ func constructOptionsFromConfigMap(log *logr.Logger, configmap *corev1.ConfigMap
 	if len(msgs) > 0 && log != nil {
 		log.Error(fmt.Errorf("some settings in the configmap are invalid"), strings.Join(msgs, "\n"))
 	}
+
+	return nil
+}
+
+// resolveImageOptions resolves PodImage and DriverImage using the centralized image resolver
+// This checks RELATED_IMAGE_* env vars first, then falls back to ConfigMap values
+func resolveImageOptions(ctx context.Context, c client.Client, configMapName, namespace string) error {
+	// Resolve pod image (env var → configmap → default)
+	podImage, err := images.ResolveImage(ctx, c, images.LMESPodImageKey, configMapName, namespace, DefaultPodImage)
+	if err != nil {
+		return fmt.Errorf("resolving LMES pod image: %w", err)
+	}
+	Options.PodImage = podImage
+
+	// Resolve driver image (env var → configmap → default)
+	driverImage, err := images.ResolveImage(ctx, c, images.LMESDriverImageKey, configMapName, namespace, DefaultDriverImage)
+	if err != nil {
+		return fmt.Errorf("resolving LMES driver image: %w", err)
+	}
+	Options.DriverImage = driverImage
 
 	return nil
 }

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -314,6 +314,12 @@ func (r *LMEvalJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 		log.Info("Constructed options from configmap", "options", Options)
 
+		// Resolve images using centralized resolver (RELATED_IMAGE_* env vars → ConfigMap → defaults)
+		if err := resolveImageOptions(ctx, r.Client, r.ConfigMap, r.Namespace); err != nil {
+			return err
+		}
+		log.Info("Resolved images", "podImage", Options.PodImage, "driverImage", Options.DriverImage)
+
 		// Read DSC configuration if available
 		dscReader := dsc.NewDSCConfigReader(r.Client, r.Namespace)
 		if dscConfig, err := dscReader.ReadDSCConfig(ctx, &log); err != nil {

--- a/controllers/nemo_guardrails/deployment.go
+++ b/controllers/nemo_guardrails/deployment.go
@@ -9,6 +9,7 @@ import (
 
 	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/nemo_guardrails/templates"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,13 +39,13 @@ func GetRBACConfigName(nemoGuardrails nemoguardrailsv1alpha1.NemoGuardrails) str
 
 // setAuthConfig will create a KubeRBACProxyConfig inside the DeploymentConfig for use in template parsing
 func (r *NemoGuardrailsReconciler) setAuthConfig(ctx context.Context, nemoGuardrails *nemoguardrailsv1alpha1.NemoGuardrails, deploymentConfig *DeploymentConfig) error {
-	// ==== get kube-rbac-proxy image from trustyai configmap ===========================================================
-	authImage, err := utils.GetImageFromConfigMap(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
+	// ==== get kube-rbac-proxy image from env var or configmap ===========================================================
+	authImage, err := images.GetImageFromConfigMap(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
 	if err != nil {
-		utils.LogErrorRetrieving(ctx, err, "oauth image from configmap", constants.ConfigMap, r.Namespace)
+		utils.LogErrorRetrieving(ctx, err, "oauth image from env var or configmap", constants.ConfigMap, r.Namespace)
 		return err
 	}
-	log.FromContext(ctx).Info("using AuthProxyImage " + authImage + " " + "from config map " + r.Namespace + ":" + constants.ConfigMap)
+	log.FromContext(ctx).Info("using AuthProxyImage " + authImage)
 
 	deploymentConfig.KubeRbacProxyConfig = &utils.KubeRBACProxyConfig{
 		Suffix:             "",
@@ -149,10 +150,10 @@ func (r *NemoGuardrailsReconciler) mountNemoConfigs(ctx context.Context, nemoGua
 func (r *NemoGuardrailsReconciler) createDeployment(ctx context.Context, nemoGuardrails *nemoguardrailsv1alpha1.NemoGuardrails, caBundleInitContainerConfig utils.CABundleInitContainerConfig, configMapsToMount []corev1.ConfigMap) (*appsv1.Deployment, error) {
 	var containerImages ContainerImages
 
-	// ==== get nemo guardrails image from trustyai configmap ===========================================================
-	nemoGuardrailsImage, err := utils.GetImageFromConfigMap(ctx, r.Client, nemoGuardrailsImageKey, constants.ConfigMap, r.Namespace)
+	// ==== get nemo guardrails image from env var or configmap ===========================================================
+	nemoGuardrailsImage, err := images.GetImageFromConfigMap(ctx, r.Client, nemoGuardrailsImageKey, constants.ConfigMap, r.Namespace)
 	if err != nil {
-		utils.LogErrorRetrieving(ctx, err, "nemo-guardrails image from configmap", constants.ConfigMap, r.Namespace)
+		utils.LogErrorRetrieving(ctx, err, "nemo-guardrails image from env var or configmap", constants.ConfigMap, r.Namespace)
 		return nil, err
 	}
 	if nemoGuardrailsImage == "" {

--- a/controllers/tas/deployment.go
+++ b/controllers/tas/deployment.go
@@ -2,6 +2,7 @@ package tas
 
 import (
 	"context"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	"reflect"
 	"strconv"
@@ -56,10 +57,10 @@ func (r *TrustyAIServiceReconciler) createDeploymentObject(ctx context.Context, 
 	}
 
 	pvcName := generatePVCName(instance)
-	// Get Kube-RBAC-proxy image from ConfigMap
-	kubeRBACProxyImage, err := utils.GetImageFromConfigMapWithFallback(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace, defaultKubeRBACProxyImage)
+	// Get Kube-RBAC-proxy image (env var first, then ConfigMap)
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace, defaultKubeRBACProxyImage)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Error getting Kube-RBAC-Proxy image from ConfigMap. Using the default image value of "+defaultKubeRBACProxyImage)
+		log.FromContext(ctx).Error(err, "Error resolving Kube-RBAC-Proxy image. Using the default image value of "+defaultKubeRBACProxyImage)
 	}
 
 	deploymentConfig := DeploymentConfig{
@@ -174,12 +175,12 @@ func (r *TrustyAIServiceReconciler) updateDeployment(ctx context.Context, cr *tr
 
 func (r *TrustyAIServiceReconciler) ensureDeployment(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, caBundle CustomCertificatesBundle, migration bool) error {
 
-	// Get image and tag from ConfigMap
+	// Get image from env var or ConfigMap
 	// If there's a ConfigMap with custom images, it is only applied when the operator is first deployed
 	// Changing (or creating) the ConfigMap after the operator is deployed will not have any effect
-	image, err := utils.GetImageFromConfigMapWithFallback(ctx, r.Client, configMapServiceImageKey, constants.ConfigMap, r.Namespace, defaultImage)
+	image, err := images.ResolveImage(ctx, r.Client, configMapServiceImageKey, constants.ConfigMap, r.Namespace, defaultImage)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Error getting TrustyAI Service image from ConfigMap. Using the default image value of "+defaultImage)
+		log.FromContext(ctx).Error(err, "Error resolving TrustyAI Service image. Using the default image value of "+defaultImage)
 	}
 
 	deploy := &appsv1.Deployment{}


### PR DESCRIPTION
* feat(images): add RELATED_IMAGE_* env var support for operand image resolution

Add unified image resolver that checks RELATED_IMAGE_ODH_* environment variables first, then falls back to ConfigMap values. This enables the modular architecture where the ODH platform operator injects image references via ClusterServiceVersion env vars, while maintaining backward compatibility with ConfigMap-based resolution.

Mapping of 10 operand images:
- trustyaiServiceImage → RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
- evalHubImage → RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
- kube-rbac-proxy → RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
- lmes-pod-image → RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
- lmes-driver-image → RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
- guardrails-orchestrator-image → RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE
- guardrails-built-in-detector-image → RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE
- guardrails-sidecar-gateway-image → RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE
- garak-provider-image → RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
- nemo-guardrails-image → RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE

Changes:
- New package: controllers/images (133 lines)
  - resolver.go: ResolveImage() with env-var-first logic
  - resolver_test.go: 10 unit tests (100% coverage)
- Updated 6 controller files with 10 call sites:
  - tas/deployment.go (2 call sites)
  - gorch/deployment.go (3 call sites)
  - gorch/auth.go (1 call site)
  - evalhub/deployment.go (1 call site)
  - evalhub/configmap.go (1 private method refactored)
  - nemo_guardrails/deployment.go (2 call sites)

Acceptance criteria met:
✅ controllers/images/resolver.go created with env-var-first logic ✅ Unit tests with 100% coverage
✅ All controller image lookups use new resolver
✅ If env var is set, ConfigMap value is ignored
✅ If env var is unset, ConfigMap fallback works as before

Part of: RHOAIENG-60939 (TrustyAI modular architecture migration)
Implements: GAP-02 from RHOAIENG-66846



* fix: add kustomize config, fix error handling, convert tests to Ginkgo

- Add RELATED_IMAGE_ODH_* env vars to manager.yaml with kustomize substitution
- Add spec/template/spec/containers[]/env[]/value to varReference in params.yaml
- Add missing image vars (lmes-driver, guardrails, nemo) to kustomization.yaml
- Fix missing error return in controllers/gorch/deployment.go:58-63
- Convert controllers/images tests from standard Go testing to Ginkgo v2 + Gomega
- All tests passing (10/10 specs)

Addresses PR #766 review feedback for ODH deployment compatibility.



* fix: check os.Unsetenv error in test cleanup

Addresses CodeRabbit review feedback - ensure all os package error returns are checked, including in test cleanup helpers.



* fix: remove unused images import from evalhub controllers

Main branch evalhub controllers don't use the images package. Remove unused import that was added during rebase conflict resolution.

Fixes build error: imported and not used



* refactor: address Rui's review feedback

- Update LMES controller to use images.ResolveImage Added resolveImageOptions() to resolve pod and driver images via centralized resolver after ConfigMap load

- Update EvalHub controller to use images.ResolveImage Replaced getImageFromConfigMap() calls in deployment.go, mcp_deployment.go, and configmap.go with images.ResolveImage()

- Add structured logging to images.ResolveImage Log resolution source (env/configmap/fallback) with key and value

- Update circular import comment in resolver.go Cleaner comment about future refactoring to shared package

Addresses review comments from ruivieira on PR #766



* docs: reference issue #783 in circular import comment

Links to tracking issue for future ConfigMap helper refactoring.

Refs #783

* test: fix EvalHub error message assertions

Update 3 test assertions to match the new error message format from the image resolver refactor. The error message changed from:
  "getting kube-rbac-proxy image"
to:
  "resolving kube-rbac-proxy image: failed to resolve image..."

This aligns tests with the actual error messages generated by the centralized images.ResolveImage() function when the operator ConfigMap is missing.

Fixes:
- controllers/evalhub/deployment_test.go:322
- controllers/evalhub/deployment_test.go:699
- controllers/evalhub/build_test.go:219

Related: #766

* fix: use effectiveOperatorConfigMapName for EvalHub image resolution

Apply CodeRabbit's suggested fix to respect the custom operator ConfigMap setting when resolving images. Changed all EvalHub image lookups from hardcoded 'configMapName' to 'r.effectiveOperatorConfigMapName()'.

This ensures that when users override the operator ConfigMap via the OperatorConfigMapName field, image resolution uses the correct ConfigMap.

Files changed:
- controllers/evalhub/configmap.go: EvalHub image in config generation
- controllers/evalhub/deployment.go: EvalHub & kube-rbac-proxy images
- controllers/evalhub/mcp_deployment.go: MCP EvalHub & kube-rbac-proxy images

This is consistent with how resource overrides work elsewhere in the EvalHub controller (e.g., resource names, service accounts).

Note: This only affects custom dev deployments; never used in ODH/RHOAI.

Addresses: https://github.com/trustyai-explainability/trustyai-service-operator/pull/766#discussion_r3468546757

---------