### PR TITLE
fix: add COPY pkg/ pkg/ to Dockerfile.konflux

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -19,6 +19,7 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
Cherry-pick of #1867 to main.

## Summary

- `pkg/configmap` was introduced in commit a7c6fc7 and `COPY pkg/ pkg/` was added to `Dockerfile` but not to `Dockerfile.konflux`
- This caused the Konflux hermetic build to fail on all 4 architectures (x86_64, ppc64le, aarch64, s390x) with: `no required module provides package .../pkg/configmap`

## Test plan
- [ ] Verify Konflux pipeline passes after merge