### PR TITLE
fix(operator): guard webhook registration behind TAS service check (#829)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,7 +60,10 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const serviceEvalHub = "EVALHUB"
+const (
+	serviceEvalHub = "EVALHUB"
+	serviceTAS     = "TAS"
+)
 
 var (
 	scheme   = runtime.NewScheme()
@@ -142,16 +145,13 @@ func main() {
 				},
 			},
 		},
-		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
-			Port:    9443,
-			TLSOpts: tlsOpts,
-		}),
 		// LeaderElectionReleaseOnCancel: true,
 	}
 
-	if slices.Contains(enabledServices, serviceEvalHub) {
+	if slices.Contains(enabledServices, serviceEvalHub) || slices.Contains(enabledServices, serviceTAS) {
 		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
-			Port: 9443,
+			Port:    9443,
+			TLSOpts: tlsOpts,
 		})
 	}
 
@@ -168,9 +168,11 @@ func main() {
 		}
 	}
 
-	if err := ctrl.NewWebhookManagedBy(mgr).For(&tasv1.TrustyAIService{}).Complete(); err != nil {
-		setupLog.Error(err, "unable to create TrustyAIService conversion webhook")
-		os.Exit(1)
+	if slices.Contains(enabledServices, serviceTAS) {
+		if err := ctrl.NewWebhookManagedBy(mgr).For(&tasv1.TrustyAIService{}).Complete(); err != nil {
+			setupLog.Error(err, "unable to create TrustyAIService conversion webhook")
+			os.Exit(1)
+		}
 	}
 
 	recorder := mgr.GetEventRecorderFor("trustyai-service-operator")


### PR DESCRIPTION
* fix(operator): guard webhook registration behind TAS service check

Remove unconditional webhook server initialization and TrustyAIService webhook registration. Both are now properly guarded behind service availability checks, preventing crashes when the operator runs in modes without TAS enabled (e.g., mcp-guardrails).

* fix(operator): unify webhook server init to always pass tlsOpts

The if/else if branch created the webhook server without TLS when only EVALHUB was enabled, and dropped it entirely when both services were active. Collapse into a single condition so the server is created once with tlsOpts whenever either service is enabled.