### PR TITLE
fix(evalhub): grant evaluation verbs to evalhub-user Role (#835)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ EvalHub deployment mode is controlled by `spec.tenancy` on the EvalHub CR (`mult
 - **`multi` (default)**: One EvalHub in a control-plane namespace serves multiple tenant namespaces labelled `evalhub.trustyai.opendatahub.io/tenant`. The operator provisions job ServiceAccounts, ClusterRole RoleBindings, service-CA ConfigMaps, and `evalhub-discovery` ConfigMaps in each tenant namespace — `tenant_namespaces.go`.
 - **`single`**: EvalHub runs in the workload namespace only. No cross-namespace tenant discovery or propagation. The operator creates namespace-scoped convenience Roles — `tenant_roles.go`:
   - `evalhub-tenant-admin` — full CRUD on EvalHub resources + MLflow experiment read
-  - `evalhub-user` — read collections/providers, submit via `evalhubs/proxy`, create status-events
+  - `evalhub-user` — evaluations job lifecycle (get/list/create/update/patch/delete), read collections/providers, submit via `evalhubs/proxy`, create status-events
   - `evalhub-tenant-admin-binding` — binds admin Role to `system:serviceaccounts:<namespace>`
   - Roles are GC'd via owner references; cleaned up on switch back to `multi`.
 

--- a/controllers/evalhub/tenant_roles.go
+++ b/controllers/evalhub/tenant_roles.go
@@ -157,13 +157,19 @@ func tenantAdminRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 }
 
 // tenantUserRules returns the PolicyRules for the evalhub-user Role.
-// Read on collections/providers, submit evaluations, read MLflow experiments.
+// Evaluation job lifecycle (list/create/get/update/patch/delete), read collections/providers,
+// submit via proxy, create status-events, and MLflow experiment access for submission.
 func tenantUserRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},
 			Resources: []string{"evalhubs"},
 			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evaluations"},
+			Verbs:     []string{"get", "list", "create", "update", "patch", "delete"},
 		},
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},

--- a/controllers/evalhub/tenant_roles_test.go
+++ b/controllers/evalhub/tenant_roles_test.go
@@ -2,11 +2,16 @@ package evalhub
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,3 +163,64 @@ func TestReconcileSingleTenancyRoles_SwitchSingleToMulti(t *testing.T) {
 		assert.True(t, errors.IsNotFound(err))
 	})
 }
+
+var _ = Describe("reconcileSingleTenancyRoles evaluations access", func() {
+	const evalHubName = "tenant-roles-evalhub"
+
+	var (
+		testNamespace string
+		namespace     *corev1.Namespace
+		evalHub       *evalhubv1.EvalHub
+		reconciler    *EvalHubReconciler
+	)
+
+	BeforeEach(func() {
+		testNamespace = fmt.Sprintf("evalhub-tenant-roles-%d", time.Now().UnixNano())
+		namespace = createNamespace(testNamespace)
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+
+		evalHub = createEvalHubInstanceWithSQLite(evalHubName, testNamespace)
+		evalHub.Spec.Tenancy = evalhubv1.TenancySingle
+		Expect(k8sClient.Create(ctx, evalHub)).To(Succeed())
+
+		reconciler, _ = setupReconciler(testNamespace)
+	})
+
+	AfterEach(func() {
+		cleanupResourcesInNamespace(testNamespace, evalHub, nil)
+		_ = k8sClient.Delete(ctx, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: tenantUserRoleName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: tenantAdminRoleName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: tenantAdminBindingName, Namespace: testNamespace},
+		})
+		deleteNamespace(namespace)
+		evalHub, namespace = nil, nil
+	})
+
+	It("user Role grants evaluations job lifecycle", func() {
+		Expect(reconciler.reconcileSingleTenancyRoles(ctx, evalHub)).To(Succeed())
+
+		role := &rbacv1.Role{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      tenantUserRoleName,
+				Namespace: testNamespace,
+			}, role)
+		}, timeout, interval).Should(Succeed())
+
+		found := false
+		for _, rule := range role.Rules {
+			if len(rule.Resources) == 1 && rule.Resources[0] == "evaluations" {
+				Expect(rule.APIGroups).To(Equal([]string{"trustyai.opendatahub.io"}))
+				Expect(rule.ResourceNames).To(BeEmpty())
+				Expect(rule.Verbs).To(ConsistOf("get", "list", "create", "update", "patch", "delete"))
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue(), "user Role must grant evaluations for ListEvaluationJobs and job lifecycle")
+	})
+})


### PR DESCRIPTION
* fix(evalhub): grant evaluations CRUD access to single-tenancy user Role

* docs(evalhub): update single-tenancy user Role description in CLAUDE.md

* test(evalhub): migrate single-tenancy evaluations role test to Ginkgo integration test

* test(evalhub): tighten assertions for single-tenancy evaluations role rule

* docs(evalhub): include patch verb in tenant user Role description