### PR TITLE
fix: point gatekeeper workflow to main branch

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -8,5 +8,5 @@ on:
 jobs:
   post-codefreeze-gate:
     if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
-    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@gatekeeper
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
     secrets: inherit


### PR DESCRIPTION
Updates the reusable workflow reference from `@gatekeeper` to `@main`.